### PR TITLE
Use same version of vcpkg and same packages as vgc

### DIFF
--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -82,8 +82,6 @@ jobs:
     - name: Configure vckpg
       working-directory: ${{github.workspace}}
       run: |
-        cd ..
-        mkdir vcpkg
         PARENT="$(cmd //c cd)" # Current folder in 'D:\...' format (pwd would do '/d/...')
         echo "VCPKG_ROOT_PARENT=$PARENT" >> $GITHUB_ENV
         echo "VCPKG_ROOT=$PARENT/vcpkg" >> $GITHUB_ENV
@@ -96,7 +94,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{env.VCPKG_ROOT}}
-        key: vcpkg=${{env.VCPKG_VERSION}} triplet=${{env.VCPKG_DEFAULT_TRIPLET}} msvc=${{env.MSVC_VERSION}} packages=${{env.VCPKG_PACKAGES}}
+        key: v2 vcpkg=${{env.VCPKG_VERSION}} triplet=${{env.VCPKG_DEFAULT_TRIPLET}} msvc=${{env.MSVC_VERSION}} packages=${{env.VCPKG_PACKAGES}}
 
     - if: ${{ steps.cache-vcpkg.outputs.cache-hit != 'true' }}
       name: Bootstrap vcpkg and install packages (if cache miss)
@@ -106,10 +104,10 @@ jobs:
         git clone --depth=1 --branch "$VCPKG_VERSION" https://github.com/microsoft/vcpkg.git
 
         # Bootstrap
+        cd vcpkg
         cmd.exe /c bootstrap-vcpkg.bat
 
         # Create custom triplet that only compile binaries with the given VCPKG_BUILD_TYPE
-        cd vcpkg
         mkdir "$VCPKG_OVERLAY_TRIPLETS"
         TRIPLET_FILE="$VCPKG_OVERLAY_TRIPLETS/$VCPKG_DEFAULT_TRIPLET.cmake"
         cp triplets/x64-windows.cmake "$TRIPLET_FILE"
@@ -118,7 +116,7 @@ jobs:
         # Install packages
         # Note: "IFS" = Input Field Separators. Makes it possible to interpret ';' as argument separator.
         #       We surround the command by parentheses so that IFS is only redefined in a subshell.
-        (IFS=';'; vcpkg.exe \
+        (IFS=';'; ./vcpkg.exe \
           --vcpkg-root="$VCPKG_ROOT" \
           --overlay-triplets="$VCPKG_OVERLAY_TRIPLETS" \
           --triplet="$VCPKG_DEFAULT_TRIPLET" \

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -153,3 +153,4 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/build
       run: cmake --build .
+

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -5,10 +5,10 @@ on: [push, pull_request]
 env:
   BUILD_TYPE: Release
   MSVC_VERSION: 2019
-  VCPKG_VERSION: 2022.05.10
+  VCPKG_VERSION: 2022.10.19
   VCPKG_INSTALL_OPTIONS: --binarysource=clear
   VCPKG_BUILD_TYPE: release
-  VCPKG_PACKAGES: freetype;fmt
+  VCPKG_PACKAGES: freetype;harfbuzz
 
 defaults:
   run:
@@ -116,7 +116,7 @@ jobs:
 
         # Install packages
         # Note: "IFS" = Input Field Separators. Makes it possible to interpret ';' as argument separator.
-        #       We surround the command by parentheseses so that IFS is only redefined in a subshell.
+        #       We surround the command by parentheses so that IFS is only redefined in a subshell.
         (IFS=';'; vcpkg.exe \
           --vcpkg-root="$VCPKG_ROOT" \
           --overlay-triplets="$VCPKG_OVERLAY_TRIPLETS" \

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -83,6 +83,7 @@ jobs:
       working-directory: ${{github.workspace}}
       run: |
         cd ..
+        mkdir vcpkg
         PARENT="$(cmd //c cd)" # Current folder in 'D:\...' format (pwd would do '/d/...')
         echo "VCPKG_ROOT_PARENT=$PARENT" >> $GITHUB_ENV
         echo "VCPKG_ROOT=$PARENT/vcpkg" >> $GITHUB_ENV

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Configure vckpg
       working-directory: ${{github.workspace}}
       run: |
+        cd ..
         PARENT="$(cmd //c cd)" # Current folder in 'D:\...' format (pwd would do '/d/...')
         echo "VCPKG_ROOT_PARENT=$PARENT" >> $GITHUB_ENV
         echo "VCPKG_ROOT=$PARENT/vcpkg" >> $GITHUB_ENV

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -82,7 +82,8 @@ jobs:
     - name: Configure vckpg
       working-directory: ${{github.workspace}}
       run: |
-        echo "VCPKG_ROOT_PARENT=${{github.workspace}}" >> $GITHUB_ENV
+        PARENT="${{github.workspace}}"
+        echo "VCPKG_ROOT_PARENT=$PARENT" >> $GITHUB_ENV
         echo "VCPKG_ROOT=$PARENT/vcpkg" >> $GITHUB_ENV
         echo "VCPKG_TOOLCHAIN_FILE=$PARENT/vcpkg/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
         echo "VCPKG_OVERLAY_TRIPLETS=$PARENT/vcpkg/custom-triplets" >> $GITHUB_ENV
@@ -93,7 +94,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{env.VCPKG_ROOT}}
-        key: v2 vcpkg=${{env.VCPKG_VERSION}} triplet=${{env.VCPKG_DEFAULT_TRIPLET}} msvc=${{env.MSVC_VERSION}} packages=${{env.VCPKG_PACKAGES}}
+        key: v3 vcpkg=${{env.VCPKG_VERSION}} triplet=${{env.VCPKG_DEFAULT_TRIPLET}} msvc=${{env.MSVC_VERSION}} packages=${{env.VCPKG_PACKAGES}}
 
     - if: ${{ steps.cache-vcpkg.outputs.cache-hit != 'true' }}
       name: Bootstrap vcpkg and install packages (if cache miss)

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -151,4 +151,3 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/build
       run: cmake --build .
-

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -151,3 +151,4 @@ jobs:
     - name: Build
       working-directory: ${{github.workspace}}/build
       run: cmake --build .
+

--- a/.github/workflows/windows-nomanifestmode.yml
+++ b/.github/workflows/windows-nomanifestmode.yml
@@ -82,9 +82,7 @@ jobs:
     - name: Configure vckpg
       working-directory: ${{github.workspace}}
       run: |
-        cd ..
-        PARENT="$(cmd //c cd)" # Current folder in 'D:\...' format (pwd would do '/d/...')
-        echo "VCPKG_ROOT_PARENT=$PARENT" >> $GITHUB_ENV
+        echo "VCPKG_ROOT_PARENT=${{github.workspace}}" >> $GITHUB_ENV
         echo "VCPKG_ROOT=$PARENT/vcpkg" >> $GITHUB_ENV
         echo "VCPKG_TOOLCHAIN_FILE=$PARENT/vcpkg/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
         echo "VCPKG_OVERLAY_TRIPLETS=$PARENT/vcpkg/custom-triplets" >> $GITHUB_ENV
@@ -101,6 +99,9 @@ jobs:
       name: Bootstrap vcpkg and install packages (if cache miss)
       working-directory: ${{env.VCPKG_ROOT_PARENT}}
       run: |
+        # Delete manifest file, otherwise, we cannot manually install packages
+        rm "${{github.workspace}}/vcpkg.json"
+
         # Download vcpkg
         git clone --depth=1 --branch "$VCPKG_VERSION" https://github.com/microsoft/vcpkg.git
 


### PR DESCRIPTION
I have the following errors in the vgc repo:

https://github.com/vgc/vgc/actions/runs/3563337474/jobs/5986006974

```
Cache Size: ~186 MB (195145441 B)
C:\Windows\System32\tar.exe -z -xf D:/a/_temp/c62ec381-2562-4554-ae09-1d74e0838c1f/cache.tgz -P -C D:/a/vgc/vgc
../vcpkg/buildtrees/harfbuzz/src/5.0.1-abd09462bc.clean/README: Can't create '\\\\?\\D:\\a\\vgc\\vgc\\..\\vcpkg\\buildtrees\\harfbuzz\\src\\5.0.1-abd09462bc.clean\\README'
tar.exe: Error exit delayed from previous errors.
Warning: Failed to restore: Tar failed with error: The process 'C:\Windows\System32\tar.exe' failed with exit code 1
```

Trying to reproduce it here to understand what's wrong.